### PR TITLE
Mask oauth tokens & send messages as `text`

### DIFF
--- a/src/main/java/jenkins/plugins/hipchat/impl/HipChatV2Service.java
+++ b/src/main/java/jenkins/plugins/hipchat/impl/HipChatV2Service.java
@@ -45,6 +45,7 @@ public class HipChatV2Service extends HipChatService {
 
                 JSONObject notification = new JSONObject();
                 notification.put("message", message);
+                notification.put("message_format", "text");
                 notification.put("color", color);
                 notification.put("notify", notify);
                 post.setRequestEntity(new StringRequestEntity(notification.toString(), "application/json", "UTF-8"));

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:entry title="${%Auth Token}" help="/plugin/hipchat/help-projectConfig-token.html">
-        <f:textbox name="hipchat.token" value="${instance.token}" />
+        <f:password name="hipchat.token" value="${instance.token}" />
     </f:entry>
     <f:entry title="${%Project Room}" help="/plugin/hipchat/help-projectConfig-hipChatRoom.html">
         <f:textbox name="hipchat.room" value="${instance.room}" />

--- a/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/hipchat/HipChatNotifier/global.jelly
@@ -7,7 +7,7 @@
             <f:checkbox name="hipchat.v2Enabled" checked="${descriptor.v2Enabled}"/>
         </f:entry>
         <f:entry title="${%API Token}" help="/plugin/hipchat/help-globalConfig-hipChatToken.html">
-            <f:textbox name="hipchat.token" value="${descriptor.token}" />
+            <f:password name="hipchat.token" value="${descriptor.token}" />
         </f:entry>
         <f:entry title="${%Room}" help="/plugin/hipchat/help-globalConfig-hipChatRoom.html">
             <f:textbox name="hipchat.room" value="${descriptor.room}" />

--- a/src/main/resources/jenkins/plugins/hipchat/Messages.properties
+++ b/src/main/resources/jenkins/plugins/hipchat/Messages.properties
@@ -7,12 +7,12 @@ StartWithChanges=Started by changes from {0} ({1} file(s) changed)
 Started=Starting...
 BackToNormal=Back to normal
 Success=Success
-Failure=<b>FAILURE</b>
+Failure=FAILURE
 Aborted=ABORTED
 NotBuilt=Not built
 Unstable=UNSTABLE
 
-JobStarted=$JOB_NAME #$BUILD_NUMBER $STATUS ($CHANGES_OR_CAUSE) (<a href="$URL">Open</a>)
-JobCompleted=$JOB_NAME #$BUILD_NUMBER $STATUS after $DURATION (<a href="$URL">Open</a>)
+JobStarted=$JOB_NAME #$BUILD_NUMBER $STATUS ($CHANGES_OR_CAUSE) ($URL)
+JobCompleted=$JOB_NAME #$BUILD_NUMBER $STATUS after $DURATION ($URL)
 
 Unknown=Unknown


### PR DESCRIPTION
By sending messages in text form, we can support mentions, emoticons, url auto-detection and slash commands.

Tested locally with Jenkins 1.6.x and JDK 1.7.x
